### PR TITLE
Null instance fix

### DIFF
--- a/fps/player.gd
+++ b/fps/player.gd
@@ -164,11 +164,12 @@ func interact():
 				if Input.is_action_just_pressed("interact"):
 					inventory_handler.pick_to_inventory(dropped_item)
 			return
-		if node.is_in_group("placeable"):
-			if Input.is_action_just_pressed("interact_item"):
-				var item = hotbar.get_selected_item()
-				if item != null:
-					place_item(item, raycast.get_collision_point())
+		if node != null:
+			if node.is_in_group("placeable"):
+				if Input.is_action_just_pressed("interact_item"):
+					var item = hotbar.get_selected_item()
+					if item != null:
+						place_item(item, raycast.get_collision_point())
 	interact_message.visible = false
 	interact_message_position.position = default_interact_message_position
 


### PR DESCRIPTION
I was getting this error when picking up items: "Attempt to call function 'is_in_group' in base 'null instance' on a null instance"

Video with the bug:
https://drive.google.com/file/d/12DoBIOTe3VrW-zxasPUBMvF7sPRaazza/view

The demo was working anyway, but it would take me out of the game. Adding the null check seems to fix it.